### PR TITLE
Changing ISM behaviour

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM golang:1.18 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -4,6 +4,8 @@ const (
 	caCertLifeTimeYears   = 10
 	certLifeTimeYears     = 1
 	subresourceNamePrefix = "opensearch"
+
+	IndexStateManagementPolicyProtectionFinalizer = "opensearch.my.domain/ism-policy-protection"
 )
 
 var (

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller
   namespace: system
 spec:
   template:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -8,7 +8,7 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller
   namespace: system
   labels:
     control-plane: controller-manager


### PR DESCRIPTION
Controller is failing if Cluster resource has been deleted earlier. Added unconditionally deleting IndexStateManagementPolicy resource if corresponding Cluster won't be found.